### PR TITLE
use -prune find option when removing __pycache__ dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ console3:
 
 cleanpyc:
 	find . -name *.pyc -exec rm {} \;
-	find . -name __pycache__ -exec rm -rf {} \;
+	find . -name __pycache__ -exec rm -rf {} \;  -prune
 
 clean: cleanpyc
 	rm -rf ${DOCS_DIR}


### PR DESCRIPTION
find tries to descend to the directory that has just been deleted, prune fix it

Closes: https://github.com/pmatiello/python-graph/issues/118